### PR TITLE
Clarify error messages

### DIFF
--- a/deep-cloning.gemspec
+++ b/deep-cloning.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name               = 'deep-cloning'
-  s.version            = '0.1.3'
+  s.version            = '0.1.4'
   s.platform           = Gem::Platform::RUBY
   s.authors            = ['Nilton Vasques']
   s.email              = ['nilton.vasques@gmail.com']

--- a/lib/deep_cloning.rb
+++ b/lib/deep_cloning.rb
@@ -93,8 +93,9 @@ module DeepCloning
           end
         else
           @opts[p.class_name] = {} unless @opts[p.class_name]
-          @must_ignore << p.class_name unless safe_child?(cell, p)
-          safe_child?(cell, p)
+          safe_child = safe_child?(cell, p)
+          @must_ignore << p.class_name unless safe_child
+          safe_child
         end
       end.all?(&:present?)
     end


### PR DESCRIPTION
- [x] Improve the error message of `cannot duplicate the hierarchy`. Now the gem tell us which classes may need be ignored in order to be able to duplicate the hierarchy.
- [x] Improve the error message regarding the **validations**. Now the message is also showing the **class** which had validation errors inside.
- [x] Add `safe_child?` method.
- [x] Change
```rb
array.reduce(true) { |result, value| result and value }
```
to
```rb
array.all?(&:present?)
```
They have same boolean result in this case.

- [x] Update gem **version**.