### PR TITLE
Make skip? moment optional

### DIFF
--- a/deep-cloning.gemspec
+++ b/deep-cloning.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name               = 'deep-cloning'
-  s.version            = '0.1.4'
+  s.version            = '0.1.5'
   s.platform           = Gem::Platform::RUBY
   s.authors            = ['Nilton Vasques', 'Victor Cordeiro', 'Beatriz Fagundes']
   s.email              = ['nilton.vasques@gmail.com', 'victorcorcos@gmail.com', 'beatrizsfslima@gmail.com']

--- a/lib/deep_cloning.rb
+++ b/lib/deep_cloning.rb
@@ -24,7 +24,7 @@ module DeepCloning
           @opts[clone.class.name] = { @root.id => clone }
         end
         leafs(@root).each do |cell|
-         @opts[:source] << cell if block_given? and not yield(cell, cell, :skip?)
+          @opts[:source] << cell if block_given? and not skip?(cell, &Proc.new)
         end
 
         while @opts[:source].any?
@@ -65,7 +65,7 @@ module DeepCloning
             @opts[clone.class.name][@cell.id] = clone
           end
           leafs(@cell).each do |cell|
-            @opts[:source] << cell if block_given? and not yield(cell, cell, :skip?)
+            @opts[:source] << cell if block_given? and not skip?(cell, &Proc.new)
           end
           leafs_statuses["#{@cell.class.name}_#{@cell.id}"] = true
         end
@@ -123,6 +123,12 @@ module DeepCloning
 
     def parents(node)
       parents = node.reflect_on_all_associations(:belongs_to) # name and class_name
+    end
+
+    def skip?(cell, &block)
+      skip = block.call(cell, cell, :skip?)
+      return skip if skip.in? [true, false]
+      false # If the skip? moment is not passed, its set to false.
     end
   end
 end

--- a/lib/deep_cloning.rb
+++ b/lib/deep_cloning.rb
@@ -28,9 +28,9 @@ module DeepCloning
         end
 
         while @opts[:source].any?
-          @cell = @opts[:source].detect do |n|
-            n = yield(n, n, :prepare) if block_given?
-            walk?(n)
+          @cell = @opts[:source].detect do |node|
+            node = yield(node, node, :prepare) if block_given?
+            walk?(node)
           end
           unless @cell
             ap @opts[:source].map { |s| "#{s.id} - #{s.class.name}" }

--- a/lib/deep_cloning.rb
+++ b/lib/deep_cloning.rb
@@ -24,7 +24,7 @@ module DeepCloning
           @opts[clone.class.name] = { @root.id => clone }
         end
         leafs(@root).each do |cell|
-          @opts[:source] << cell if block_given? and not skip?(cell, &Proc.new)
+          @opts[:source] << cell if block_given? and not skip?(yield(cell, cell, :skip?))
         end
 
         while @opts[:source].any?
@@ -65,7 +65,7 @@ module DeepCloning
             @opts[clone.class.name][@cell.id] = clone
           end
           leafs(@cell).each do |cell|
-            @opts[:source] << cell if block_given? and not skip?(cell, &Proc.new)
+            @opts[:source] << cell if block_given? and not skip?(yield(cell, cell, :skip?))
           end
           leafs_statuses["#{@cell.class.name}_#{@cell.id}"] = true
         end
@@ -125,8 +125,7 @@ module DeepCloning
       parents = node.reflect_on_all_associations(:belongs_to) # name and class_name
     end
 
-    def skip?(cell, &block)
-      skip = block.call(cell, cell, :skip?)
+    def skip?(cell, skip)
       return skip if skip.in? [true, false]
       false # If the skip? moment is not passed, its set to false.
     end

--- a/lib/deep_cloning.rb
+++ b/lib/deep_cloning.rb
@@ -3,7 +3,7 @@ require 'active_record'
 module DeepCloning
   # This is the main class responsible to evaluate the equations
   class Clone
-    VERSION = '0.1.4'.freeze
+    VERSION = '0.1.5'.freeze
     def initialize(root, opts = { except: [], save_root: true })
       @root = root
       @opts = opts


### PR DESCRIPTION
When using the gem, the `skip?` moment was not optional before. After this PR, this momment will be optional, if you decide not to include this moment, the **DeepClone** will assume it is `false`.

Example...
```rb
DeepCloning::Clone.new(@root, opts).replicate do |source, dest, moment|
  case moment
  when :before_save
    nil
  when :after_save
    nil
  else
    dest
  end
end
```

- [x] Make the `skip?` moment optional
- [x] Update gem version