### PR TITLE
Add including as a new option

### DIFF
--- a/deep-cloning.gemspec
+++ b/deep-cloning.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name               = 'deep-cloning'
-  s.version            = '0.1.4'
+  s.version            = '0.2.0'
   s.platform           = Gem::Platform::RUBY
   s.authors            = ['Nilton Vasques', 'Victor Cordeiro', 'Beatriz Fagundes']
   s.email              = ['nilton.vasques@gmail.com', 'victorcorcos@gmail.com', 'beatrizsfslima@gmail.com']

--- a/lib/deep_cloning.rb
+++ b/lib/deep_cloning.rb
@@ -126,8 +126,8 @@ module DeepCloning
     end
 
     def should_copy?(klass)
-      klass.in? @opts[:including] if @opts[:except].nil?
-      !klass.in? @opts[:except] if @opts[:including].nil?
+      return !klass.in? @opts[:except] if @opts[:including].nil?
+      klass.in? @opts[:including]
     end
   end
 end

--- a/lib/deep_cloning.rb
+++ b/lib/deep_cloning.rb
@@ -3,7 +3,7 @@ require 'active_record'
 module DeepCloning
   # This is the main class responsible to evaluate the equations
   class Clone
-    VERSION = '0.1.4'.freeze
+    VERSION = '0.2.0'.freeze
     def initialize(root, opts = { except: [], save_root: true })
       @root = root
       @opts = opts

--- a/lib/deep_cloning.rb
+++ b/lib/deep_cloning.rb
@@ -41,7 +41,7 @@ module DeepCloning
           @opts[@cell.class.name] = {} unless @opts[@cell.class.name]
           next if @opts[@cell.class.name][@cell.id] # already cloned?
 
-          if copy_allowed?(@cell.class.name)
+          if should_copy?(@cell.class.name)
             clone = @cell.dup
             parents(clone.class).each do |belongs_to|
               old_id = clone.send("#{belongs_to.name}_id")
@@ -76,7 +76,7 @@ module DeepCloning
       !child.respond_to?("#{parent.name}_id".to_sym) or
       child.send("#{parent.name}_id").nil? or
       @opts[parent.class_name][child.send("#{parent.name}_id")] or
-      not copy_allowed?(parent.class_name)
+      not should_copy?(parent.class_name)
       # replicated parent?
     end
 
@@ -87,7 +87,7 @@ module DeepCloning
           if cell.respond_to?("#{p.name}_id".to_sym) and cell.send("#{p.name}_id")
             class_name = cell.send("#{p.name}").class.name
             @opts[class_name] = {} unless @opts[class_name]
-            @opts[class_name][cell.send("#{p.name}_id")] or not copy_allowed?(class_name) # replicated parent?
+            @opts[class_name][cell.send("#{p.name}_id")] or not should_copy?(class_name) # replicated parent?
           else
             true
           end
@@ -104,13 +104,13 @@ module DeepCloning
       node = cell.class
       arr = []
       node.reflect_on_all_associations(:has_one).each do |c|
-        if copy_allowed?(c.class_name)
+        if should_copy?(c.class_name)
           leaf = cell.send(c.name)
           arr << leaf if leaf&.persisted? and (@opts[:source].nil? or (not leaf.in? @opts[:source]))
         end
       end
       node.reflect_on_all_associations(:has_many).each do |c|
-        if copy_allowed?(c.class_name)
+        if should_copy?(c.class_name)
           cell.send(c.name).find_in_batches.each do |leafs|
             leafs.each do |leaf|
               arr << leaf if leaf&.persisted? and (@opts[:source].nil? or (not leaf.in? @opts[:source]))
@@ -125,7 +125,7 @@ module DeepCloning
       parents = node.reflect_on_all_associations(:belongs_to) # name and class_name
     end
 
-    def copy_allowed?(klass)
+    def should_copy?(klass)
       klass.in? @opts[:including] if @opts[:except].nil?
       !klass.in? @opts[:except] if @opts[:including].nil?
     end

--- a/lib/deep_cloning.rb
+++ b/lib/deep_cloning.rb
@@ -124,5 +124,10 @@ module DeepCloning
     def parents(node)
       parents = node.reflect_on_all_associations(:belongs_to) # name and class_name
     end
+
+    def copy_allowed?(klass)
+      klass.in? @opts[:including] if @opts[:except].nil?
+      !klass.in? @opts[:except] if @opts[:including].nil?
+    end
   end
 end

--- a/lib/deep_cloning.rb
+++ b/lib/deep_cloning.rb
@@ -24,13 +24,13 @@ module DeepCloning
           @opts[clone.class.name] = { @root.id => clone }
         end
         leafs(@root).each do |cell|
-         @opts[:source] << cell if block_given? and not yield(cell, cell, :skip?)
+          @opts[:source] << cell if block_given? and not skip?(yield(cell, cell, :skip?))
         end
 
         while @opts[:source].any?
-          @cell = @opts[:source].detect do |n|
-            n = yield(n, n, :prepare) if block_given?
-            walk?(n)
+          @cell = @opts[:source].detect do |node|
+            node = yield(node, node, :prepare) if block_given?
+            walk?(node)
           end
           unless @cell
             ap @opts[:source].map { |s| "#{s.id} - #{s.class.name}" }
@@ -65,7 +65,7 @@ module DeepCloning
             @opts[clone.class.name][@cell.id] = clone
           end
           leafs(@cell).each do |cell|
-            @opts[:source] << cell if block_given? and not yield(cell, cell, :skip?)
+            @opts[:source] << cell if block_given? and not skip?(yield(cell, cell, :skip?))
           end
           leafs_statuses["#{@cell.class.name}_#{@cell.id}"] = true
         end
@@ -128,6 +128,11 @@ module DeepCloning
     def should_copy?(klass)
       return !klass.in? @opts[:except] if @opts[:including].nil?
       klass.in? @opts[:including]
+    end
+
+    def skip?(cell, skip)
+      return skip if skip.in? [true, false]
+      false # If the skip? moment is not passed, its set to false.
     end
   end
 end


### PR DESCRIPTION
## Description

Now we can inform which class names should be copied on the parameters when calling `replicate` via the `:include` key on the `opts`.
Previously, we could only inform which class names should **NOT** be copied via the `:except` key.

- [x] Create the `should_copy?(klass)` method, which will inform if the `klass` should be copied.
- [x] Use the `should_copy?(klass)` method when there is comparisons regarding the `@opts[:except]`.
- [x] Change version to **0.2.0**.

## Usage example

```rb
INCLUDING = %w[ClassOne ClassTwo].freeze

def opts
  { including: INCLUDING, 'RootClass' => { @root.id => @dup_root }, save_root: false }
end

DeepCloning::Clone.new(@root, opts).replicate do |source, dest, moment|
  case moment
  when :before_save
    nil
  when :after_save
    nil
  when :skip?
    false
  else
    dest
  end
end
```