### PR TITLE
Fix skip? and should_copy? bugs

### DIFF
--- a/lib/deep_cloning.rb
+++ b/lib/deep_cloning.rb
@@ -126,11 +126,11 @@ module DeepCloning
     end
 
     def should_copy?(klass)
-      return !klass.in? @opts[:except] if @opts[:including].nil?
+      return !(klass.in? @opts[:except]) if @opts[:including].nil?
       klass.in? @opts[:including]
     end
 
-    def skip?(cell, skip)
+    def skip?(skip)
       return skip if skip.in? [true, false]
       false # If the skip? moment is not passed, its set to false.
     end


### PR DESCRIPTION
## Description

I tested this new features and found these two bugs. Luckily, we didn't push the gem to the `rubygems` yet!

## Checks

- [x] Add parenthesis to the negation statement on `should_copy?()` method.
- [x] Remove the unused parameter on `skip?()` method.