### PR TITLE
Use hierarchy to bring deep clone children classes

### DIFF
--- a/deep-cloning.gemspec
+++ b/deep-cloning.gemspec
@@ -14,6 +14,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'minitest', '~> 5.10'
   s.add_development_dependency 'rake', '~> 12.1'
-  s.add_development_dependency 'hierarchy_tree'
+  s.add_development_dependency 'hierarchy_tree', '~> 0'
   s.add_dependency 'activerecord', '~> 4.2'
 end

--- a/deep-cloning.gemspec
+++ b/deep-cloning.gemspec
@@ -14,5 +14,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'minitest', '~> 5.10'
   s.add_development_dependency 'rake', '~> 12.1'
+  s.add_development_dependency 'hierarchy_tree'
   s.add_dependency 'activerecord', '~> 4.2'
 end

--- a/deep-cloning.gemspec
+++ b/deep-cloning.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name               = 'deep-cloning'
-  s.version            = '0.2.1'
+  s.version            = '0.2.2'
   s.platform           = Gem::Platform::RUBY
   s.authors            = ['Nilton Vasques', 'Victor Cordeiro', 'Beatriz Fagundes']
   s.email              = ['nilton.vasques@gmail.com', 'victorcorcos@gmail.com', 'beatrizsfslima@gmail.com']

--- a/deep-cloning.gemspec
+++ b/deep-cloning.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |s|
   s.authors            = ['Nilton Vasques', 'Victor Cordeiro', 'Beatriz Fagundes']
   s.email              = ['nilton.vasques@gmail.com', 'victorcorcos@gmail.com', 'beatrizsfslima@gmail.com']
   s.description        = 'DeepCloning is a gem that is able to replicate a set of records in depth'
-  s.homepage           = 'https://github.com/niltonvasques/deep-cloning-ruby'
+  s.homepage           = 'https://github.com/oxeanbits/deep-cloning-ruby'
   s.summary            = 'DeepCloning is a gem that is able to replicate a set of records in depth'
   s.files              = ['lib/deep_cloning.rb']
   s.test_files         = ['test/test_deep_cloning.rb']

--- a/lib/deep_cloning.rb
+++ b/lib/deep_cloning.rb
@@ -1,9 +1,10 @@
 require 'active_record'
+require 'hierarchy_tree'
 
 module DeepCloning
   # This is the main class responsible to evaluate the equations
   class Clone
-    VERSION = '0.2.1'.freeze
+    VERSION = '0.2.2'.freeze
     def initialize(root, opts = { except: [], save_root: true })
       @root = root
       @opts = opts

--- a/lib/deep_cloning.rb
+++ b/lib/deep_cloning.rb
@@ -2,7 +2,7 @@ require 'active_record'
 require 'hierarchy_tree'
 
 module DeepCloning
-  def self.including(klass)
+  def self.descendants(klass)
     Hierarchy.descendants(klass)
   end
 

--- a/lib/deep_cloning.rb
+++ b/lib/deep_cloning.rb
@@ -2,7 +2,11 @@ require 'active_record'
 require 'hierarchy_tree'
 
 module DeepCloning
-  # This is the main class responsible to evaluate the equations
+  def self.including(klass)
+    Hierarchy.descendants(klass)
+  end
+
+  # This is the main class responsible to duplicate an entire hierarchy
   class Clone
     VERSION = '0.2.2'.freeze
     def initialize(root, opts = { except: [], save_root: true })

--- a/lib/deep_cloning.rb
+++ b/lib/deep_cloning.rb
@@ -1,4 +1,3 @@
-require 'active_record'
 require 'hierarchy_tree'
 
 module DeepCloning


### PR DESCRIPTION
Add `DeepCloning.descendants(YourClass)` function, which discovers all the descendant classes from a desired class.

This can be very useful to visualize which classes will be copied through the Deep Clone `replicate()` method.

You can use the output of this function as a basis to discover which classes you want to include on the **INCLUDING** parameter or which classes you want to exclude on the **EXCLUDING** parameter. 👍

# How to use...

## Imagine you have these relations

```rb
require 'deep_cloning'

class A < ActiveRecord::Base
  has_many :bs
end

class B < ActiveRecord::Base
  has_many :cs
end

class C < ActiveRecord::Base; end
```

## Then, you can access which classes will be copied though this

```rb
DeepCloning.descendants(A)
# ["B", "C"]
```